### PR TITLE
Add nwworkingdir support

### DIFF
--- a/nw-fileDialog.js
+++ b/nw-fileDialog.js
@@ -16,10 +16,18 @@ angular.module('DWand.nw-fileDialog', [])
 
   var dialogs = {};
   
-  dialogs.saveAs = function(callback, defaultFilename, acceptTypes) {
+  dialogs.saveAs = function(callback, options, acceptTypes) {
+    options = options || {};
+    acceptTypes = options.acceptTypes || acceptTypes;
+    // For backward compatibility
+    if (typeof options is 'string') {
+      options = { defaultFilename: options };
+    }
+
     var dialog = document.createElement('input');
     dialog.type = 'file';
-    dialog.nwsaveas = defaultFilename || '';
+    dialog.nwsaveas = options.defaultFilename || '';
+    dialog.nwworkingdir = options.defaultDirectory || '';
     if (angular.isArray(acceptTypes)) {
       dialog.accept = acceptTypes.join(',');
     } else if (angular.isString(acceptTypes)) {

--- a/nw-fileDialog.js
+++ b/nw-fileDialog.js
@@ -20,7 +20,7 @@ angular.module('DWand.nw-fileDialog', [])
     options = options || {};
     acceptTypes = options.acceptTypes || acceptTypes;
     // For backward compatibility
-    if (typeof options is 'string') {
+    if (typeof options == 'string') {
       options = { defaultFilename: options };
     }
 


### PR DESCRIPTION
At first I want to thank you for this module.
I've some changes and some advice for you.
In my application I'm setting the default directory using nwworkingdir.
I've added a simple option to define that.
At the same time I moved the acceptTypes & defaultFilename into the options object.
For backwards compatibility I check the options type.
Though I think that you should move all arguments (except callback) into an object. It makes defining of additional options easier.
Also if you follow the nodejs guidelines it's favourable to have the callback as last argument.
